### PR TITLE
Filter images by language when building dist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ task createTemplatesFromGoldenMaster (
                     copy {
                         from pathToDEGoldenMaster + '/../../images/.'
                         into pathToTarget + '/images'
+                        include "**/*-${language}.*"
                     }
                 }
             }


### PR DESCRIPTION
I would like that dist packages don't contain images for languages other than the main language of the document.